### PR TITLE
Exception handler on crawler

### DIFF
--- a/fycharts/crawler_base.py
+++ b/fycharts/crawler_base.py
@@ -66,7 +66,7 @@ class SpotifyChartsBase(object):
 			"""
 			headers = {'Host':'spotifycharts.com', 'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36'}
 
-			retries = Retry(total = 10, backoff_factor = 2, status_forcelist = [500, 502, 503, 504, 404])
+			retries = Retry(total = 3, backoff_factor = 2, status_forcelist = [500, 502, 503, 504, 404])
 
 			try:
 				s = requests.Session()

--- a/fycharts/crawler_base.py
+++ b/fycharts/crawler_base.py
@@ -66,7 +66,7 @@ class SpotifyChartsBase(object):
 			"""
 			headers = {'Host':'spotifycharts.com', 'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36'}
 
-			retries = Retry(total = 3, backoff_factor = 2, status_forcelist = [500, 502, 503, 504, 404])
+			retries = Retry(total = 10, backoff_factor = 2, status_forcelist = [500, 502, 503, 504, 404])
 
 			try:
 				s = requests.Session()

--- a/fycharts/crawler_base.py
+++ b/fycharts/crawler_base.py
@@ -59,14 +59,14 @@ class SpotifyChartsBase(object):
 		return trackId
 
 
-		def makeRequests(self, url, date, region, isSkip, size):
+	def makeRequests(self, url, date, region, isSkip, size):
 			"""Make the HTTP request, clean data, and return as df
 			url - The URL to make request
 			isSkip - Whether or not to skip first row of CSV file
 			"""
 			headers = {'Host':'spotifycharts.com', 'User-Agent': 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36'}
 
-			retries = Retry(total = 3, backoff_factor = 2, status_forcelist = [500, 502, 503, 504, 404])
+			retries = Retry(total = 10, backoff_factor = 2, status_forcelist = [500, 502, 503, 504, 404])
 
 			try:
 				s = requests.Session()


### PR DESCRIPTION
Whenever the crawler ran into a connectivity or access issue, it would retry the default number of times (10) before giving up. Problem is, that crashed the crawler due to a lack of exception handling, which is problematic in long importations. This adds a simple exception handler that in case of fail simply exports a blank df.