### PR TITLE
Add timeout value to get request.

### DIFF
--- a/fycharts/crawler_base.py
+++ b/fycharts/crawler_base.py
@@ -71,7 +71,7 @@ class SpotifyChartsBase(object):
 			try:
 				s = requests.Session()
 				s.mount("https://", HTTPAdapter(max_retries = retries))
-				res = s.get(url, headers = headers)
+				res = s.get(url, headers = headers, timeout = 3)
 
 				if(res.status_code == 200):
 					if(res.headers["Content-Type"] == "text/html; charset=UTF-8"):


### PR DESCRIPTION
Added timeout value to get request. Without it, the whole download freezes, if the file on the Spotify end is missing/invalid for example in the region 'us' and date '2019-01-14'.